### PR TITLE
Fix windows version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 out
 node_modules
 .vscode-test/
-.vsix
+*.vsix

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -30,6 +30,13 @@
             "problemMatcher": [
                 "$tsc-watch"
             ]
+        },
+        {
+            "type": "npm",
+            "script": "vscode:prepublish",
+            "problemMatcher": [
+                "$tsc"
+            ]
         }
     ]
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -30,7 +30,7 @@ export function activate(context: vscode.ExtensionContext) {
 
     flashIcon = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left);
     flashIcon.text = `$(circuit-board) flash`;
-    flashIcon.tooltip = 'Flash complied mbed binary into board';
+    flashIcon.tooltip = 'Flash compiled mbed binary into board';
     flashIcon.command = 'extension.mbed.flash';        
     flashIcon.show();
 
@@ -165,7 +165,7 @@ export function mbedCompileProject() {
     const path = vscode.workspace.workspaceFolders[0].uri.fsPath;
     exec(cmd, path)
         .then(() => {
-            vscode.window.showInformationMessage(`Successfully complied`)
+            vscode.window.showInformationMessage(`Successfully compiled`)
         }).catch((reason) => {
             commandOutput.appendLine(`> ERROR: ${reason}`);
             vscode.window.showErrorMessage(reason, 'Show Output')
@@ -180,7 +180,7 @@ export function mbedCompileAndFlashProject() {
     const path = vscode.workspace.workspaceFolders[0].uri.fsPath;
     exec(cmd, path)
         .then(() => {
-            vscode.window.showInformationMessage(`Successfully complied`)
+            vscode.window.showInformationMessage(`Successfully compiled`)
         }).catch((reason) => {
             commandOutput.appendLine(`> ERROR: ${reason}`);
             vscode.window.showErrorMessage(reason, 'Show Output')

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -174,7 +174,7 @@ export function mbedCompileProject() {
 }
 
 export function mbedCompileAndFlashProject() {
-    const cmd = generateCommand(); 
+    const cmd = generateCommand() + ' -f'; 
     const folder = vscode.workspace.workspaceFolders;
 
     const path = vscode.workspace.workspaceFolders[0].uri.fsPath;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -37,7 +37,7 @@ export function activate(context: vscode.ExtensionContext) {
     logIcon = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left);
     logIcon.text = `$(terminal) serial monitor`;
     logIcon.tooltip = 'Open serial monitor';
-    logIcon.command = 'extensio.mbed.serialMonitor';
+    logIcon.command = 'extension.mbed.serialMonitor';
     logIcon.show();
 
     commandOutput = vscode.window.createOutputChannel('mbed tasks');

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -113,7 +113,7 @@ export function exec(cmd:string, cwd:string): Promise<void> {
 
 export function checkMbedInstalled(): Promise<void> {
     return new Promise((resolve, reject) => {
-        process = spawnCMD('which mbed');
+        process = (process.platform === 'win32') ? spawnCMD('where mbed') : spawnCMD('which mbed');
         process.on('close', (status) => {
             if (status) {
                 reject(`error`);
@@ -162,7 +162,7 @@ export function mbedCompileProject() {
     const cmd = generateCommand();
     const folder = vscode.workspace.workspaceFolders;
 
-    const path = vscode.workspace.workspaceFolders[0].uri.path;
+    const path = vscode.workspace.workspaceFolders[0].uri.fsPath;
     exec(cmd, path)
         .then(() => {
             vscode.window.showInformationMessage(`Successfully complied`)
@@ -174,10 +174,10 @@ export function mbedCompileProject() {
 }
 
 export function mbedCompileAndFlashProject() {
-    const cmd = generateCommand();
+    const cmd = generateCommand(); 
     const folder = vscode.workspace.workspaceFolders;
 
-    const path = vscode.workspace.workspaceFolders[0].uri.path;
+    const path = vscode.workspace.workspaceFolders[0].uri.fsPath;
     exec(cmd, path)
         .then(() => {
             vscode.window.showInformationMessage(`Successfully complied`)


### PR DESCRIPTION
This is a PR to fix the problems when running the extension under windows.
It also adds the flash function to the flash command, the ' -f' option was missing. Please note that flashing requires 'auto' or 'detect' for the target setting.
The excecution of the compile command under windows failed because the path is prepended by a '/'. The variable vscode.workspace.workspaceFolders[0].uri.fsPath contains the correct path.